### PR TITLE
v0.2.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bcbioBase
 Title: bcbio Base Functions
 Description: Base functions and generics for bcbio R packages.
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(
     person(
         given = "Michael",

--- a/R/methods-convertGenesToSymbols.R
+++ b/R/methods-convertGenesToSymbols.R
@@ -30,7 +30,7 @@ setMethod(
             return(object)
         }
         symbols <- gene2symbol[, "geneName", drop = TRUE]
-        symbols <- make.unique(symbols)
+        symbols <- make.names(symbols, unique = TRUE)
         rownames(object) <- symbols
         object
     }


### PR DESCRIPTION
Use `make.names()` instead of `make.unique()` in `convertGenesToSymbols()` method for `SummarizedExperiment` class.